### PR TITLE
fix(webapp): title for category and delegate are backwards

### DIFF
--- a/webapp/src/routes/ExpenseReport/index.js
+++ b/webapp/src/routes/ExpenseReport/index.js
@@ -185,14 +185,14 @@ const ExpenseReport = () => {
 
       <div className={classes.chartContainer}>
         <PieChartReport
-          data={delegatesList}
+          data={categoryList}
           keyTranslation={'titlePieChart1'}
           pathTranslation={'expenseRoute'}
           typeData={'expense'}
         />
         <div className={classes.verticalLine} />
         <PieChartReport
-          data={categoryList}
+          data={delegatesList}
           keyTranslation={'titlePieChart2'}
           pathTranslation={'expenseRoute'}
           typeData={'expense'}


### PR DESCRIPTION
### Title for category and delegate are backward

### What does this PR do?

- Resolve #232 

### Steps to test

1. run the project and open in your browser localhost:3000
2. click on expense in the sidebar and see the titles in the right way

#### CheckList

- [X] Follow proper Markdown format
- [X] The content is adequate
- [X] The content is available in both english and spanish
- [X] I Ran a spell check
