### PR TITLE
feat(webapp): not display data in loading treasury

### DIFF
--- a/webapp/src/components/TreasuryBalance/index.js
+++ b/webapp/src/components/TreasuryBalance/index.js
@@ -19,7 +19,8 @@ const TrasuryBalance = () => {
     <div className={classes.eosPriceContainer}>
       <label className={classes.eosPriceTitle}>{t('titleEosBalance')}</label>
       <label className={classes.eosBalance}>
-        {formatWithThousandSeparator(currencyBalance.split(' ')[0], 2)} EOS
+        {formatWithThousandSeparator(currencyBalance.split(' ')[0], 2)}{' '}
+        {currencyBalance.split(' ')[1]}
       </label>
       <label className={classes.eosBalanceInDollars}>
         $
@@ -27,7 +28,8 @@ const TrasuryBalance = () => {
           eosRate * Number(currencyBalance.split(' ')[0]),
           2
         ) || 0}{' '}
-        @ ${formatWithThousandSeparator(eosRate, 2)}/EOS
+        @ ${formatWithThousandSeparator(eosRate, 2)}
+        {eosRate > 0 ? '/EOS' : ''}
       </label>
     </div>
   )


### PR DESCRIPTION
### Not display data in loading treasury

### What does this PR do?

- Resolve #253

### Steps to test

1. show the loading only when there isn't treasury data

#### CheckList

- [X] Follow the proper Markdown format
- [X] The content is adequate
- [X] The content is available in both english and spanish
- [X] I Ran a spell check
