### PR TITLE
fix(webapp): A param was missing in the function

### DIFF
--- a/webapp/src/components/Accordion/index.js
+++ b/webapp/src/components/Accordion/index.js
@@ -66,7 +66,7 @@ const AccordionComp = ({
                 positionText={delegate?.rank?.label}
                 headItem={
                   <Typography variant="h6">
-                    {formatWithThousandSeparator(delegate?.totalRewarded)}
+                    {formatWithThousandSeparator(delegate?.totalRewarded, 4)}
                   </Typography>
                 }
                 text={t('rewarded', { ns: 'delegateRoute' })}


### PR DESCRIPTION
### A param was missing in the function

### What does this PR do?

- Resolve #270 

### Steps to test

1. Run Project
2. Enter To Delegate and scroll down
Before:
![imagen](https://user-images.githubusercontent.com/49013556/204367989-5a40c70e-6694-453c-ac18-8e74d0dc3d83.png)

Now:
![imagen](https://user-images.githubusercontent.com/49013556/204367916-6be72045-9129-4579-a337-4ea38333dc23.png)


#### CheckList

- [X] Follow proper Markdown format
- [X] The content is adequate
- [X] The content is available in both english and spanish
- [X] I Ran a spell check
