### PR TITLE
fix(hapi): fix new format elections income

### DIFF
--- a/hapi/src/services/income-frontend.service.js
+++ b/hapi/src/services/income-frontend.service.js
@@ -12,40 +12,67 @@ const generateColor = () => {
   return color
 }
 
+const createElection = (
+  newElection,
+  newDate,
+  eosClaimed,
+  eosUnclaimed,
+  usdClaimed,
+  usdUnclaimed
+) => {
+  const election = {
+    election: `Election ${newElection + 1}`,
+    date: newDate,
+    EOS_CLAIMED: Number(eosClaimed),
+    EOS_UNCLAIMED: Number(eosUnclaimed),
+    USD_CLAIMED: Number(usdClaimed),
+    USD_UNCLAIMED: Number(usdUnclaimed),
+    EOS_TOTAL: Number(eosClaimed + eosUnclaimed),
+    USD_TOTAL: Number(usdClaimed + usdUnclaimed),
+    EOS_CLAIMED_PERCENT: Number(eosClaimed / (eosClaimed + eosUnclaimed)) * 100,
+    EOS_UNCLAIMED_PERCENT:
+      Number(eosUnclaimed / (eosClaimed + eosUnclaimed)) * 100
+  }
+  return election
+}
+
 const newDataFormatByElectionsIncome = electionsList => {
   const dataElections = electionsList.total_by_category_and_election
   const historicElections = electionsList.eden_historic_election
-  const elections = []
-  for (let pos = 0; pos < dataElections.length; pos = pos + 2) {
-    const date = historicElections.find(
-      element => element.election === dataElections[pos].election
-    )
-    const election = {
-      election: `Election ${dataElections[pos].election + 1}`,
-      date: date.date_election,
-      EOS_CLAIMED: Number(dataElections[pos].amount),
-      EOS_UNCLAIMED: Number(dataElections[pos + 1]?.amount),
-      USD_CLAIMED: Number(dataElections[pos].usd_total),
-      USD_UNCLAIMED: Number(dataElections[pos + 1]?.usd_total),
-      EOS_TOTAL: Number(
-        dataElections[pos].amount + dataElections[pos + 1]?.amount
-      ),
-      USD_TOTAL: Number(
-        dataElections[pos].usd_total + dataElections[pos + 1]?.usd_total
-      ),
-      EOS_CLAIMED_PERCENT:
-        (dataElections[pos].amount /
-          (dataElections[pos].usd_total + dataElections[pos + 1]?.usd_total)) *
-        100,
-      EOS_UNCLAIMED_PERCENT:
-        (dataElections[pos + 1]?.usd_total /
-          (dataElections[pos].usd_total + dataElections[pos + 1]?.usd_total)) *
-        100
-    }
-    elections.push(election)
-  }
 
-  return elections
+  const electionsByNumber = dataElections.reduce(
+    (acc, { election, category, amount, usd_total }) => {
+      if (!acc[election]) {
+        acc[election] = {
+          election,
+          date: historicElections.find(({ election: e }) => e === election)
+            .date_election,
+          eosClaimed: 0,
+          eosUnclaimed: 0,
+          usdClaimed: 0,
+          usdUnclaimed: 0
+        }
+      }
+      acc[election][category === 'claimed' ? 'eosClaimed' : 'eosUnclaimed'] +=
+        amount
+      acc[election][category === 'claimed' ? 'usdClaimed' : 'usdUnclaimed'] +=
+        usd_total
+      return acc
+    },
+    {}
+  )
+
+  return Object.values(electionsByNumber).map(
+    ({ election, date, eosClaimed, eosUnclaimed, usdClaimed, usdUnclaimed }) =>
+      createElection(
+        election,
+        date,
+        eosClaimed,
+        eosUnclaimed,
+        usdClaimed,
+        usdUnclaimed
+      )
+  )
 }
 
 const newDataFormatByDelegatesIncome = transactionsList =>


### PR DESCRIPTION
### Fix new format elections income

### What does this PR do?

- Resolve #355 

### Steps to test

1. Run Project 
2. Enter to income and must see this:
Before:
![imagen](https://user-images.githubusercontent.com/49013556/209697019-b30ecacc-a144-4f58-9fac-d4e0686aa382.png)

Now:
![imagen](https://user-images.githubusercontent.com/49013556/209697093-46839749-e299-4b0e-9580-9929b3a90605.png)


#### CheckList

- [X] Follow proper Markdown format
- [X] The content is adequate
- [X] The content is available in both english and spanish
- [X] I Ran a spell check
